### PR TITLE
WIP: remove usage template, use FlagErrorFunc?

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/util/templates/templater.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/util/templates/templater.go
@@ -39,7 +39,6 @@ func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...CommandGr
 	}
 	templater := &templater{
 		RootCmd:       cmd,
-		UsageTemplate: MainUsageTemplate(),
 		HelpTemplate:  MainHelpTemplate(),
 		CommandGroups: groups,
 		Filtered:      filters,

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/util/templates/templates.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/util/templates/templates.go
@@ -69,13 +69,8 @@ const (
 {{end}}`
 )
 
-// MainHelpTemplate if the template for 'help' used by most commands.
+// MainHelpTemplate is the template for 'help' used by most commands.
 func MainHelpTemplate() string {
-	return `{{with or .Long .Short }}{{. | trim}}{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
-}
-
-// MainUsageTemplate if the template for 'usage' used by most commands.
-func MainUsageTemplate() string {
 	sections := []string{
 		"\n\n",
 		SectionVars,
@@ -90,12 +85,12 @@ func MainUsageTemplate() string {
 	return strings.TrimRightFunc(strings.Join(sections, ""), unicode.IsSpace)
 }
 
-// OptionsHelpTemplate if the template for 'help' used by the 'options' command.
+// OptionsHelpTemplate is the template for 'help' used by the 'options' command.
 func OptionsHelpTemplate() string {
 	return ""
 }
 
-// OptionsUsageTemplate if the template for 'usage' used by the 'options' command.
+// OptionsUsageTemplate is the template for 'usage' used by the 'options' command.
 func OptionsUsageTemplate() string {
 	return `{{ if .HasInheritedFlags}}The following options can be passed to any command:
 


### PR DESCRIPTION
@soltysh WIP, wondering if this is what we're going for?  No usage printed when bad flag is passed, only with --help. 

example:
```console
$ oc login --foo
Error: unknown flag: --foo
See 'oc login --help' for more information about a given command.

$ oc login --help
Examples:
  # Log in interactively
  oc login
  
  # Log in to the given server with the given certificate authority file
  oc login localhost:8443 --certificate-authority=/path/to/cert.crt
  
  # Log in to the given server with the given credentials (will not prompt interactively)
  oc login localhost:8443 --username=myuser --password=mypass

Options:
  -p, --password='': Password, will prompt if not provided
  -u, --username='': Username, will prompt if not provided

Usage:
  oc login [URL] [flags]

Use "oc options" for a list of global command-line options (applies to all commands).
```
```console
$ oc --foo
Error: unknown flag: --foo
See 'oc <command> --help' for more information about a given command.

$ oc --help


Basic Commands:
  login           Log in to a server
 ---
Build and Deploy Commands:
  rollout         Manage a Kubernetes deployment or OpenShift deployment config
---

Application Management Commands:
  create          Create a resource from a file or from stdin.
---
Troubleshooting and Debugging Commands:
  logs            Print the logs for a resource
  rsh             Start a shell session in a pod
 ---
Advanced Commands:
  adm             Tools for managing a cluster
  replace         Replace a resource by filename or stdin
---
Settings Commands:
  logout          End the current server session
 ---
Other Commands:
  ex              Experimental commands under active development
---
Usage:
  oc [flags]

Use "oc <command> --help" for more information about a given command.
Use "oc options" for a list of global command-line options (applies to all commands).
```